### PR TITLE
Fix wayland string protocol

### DIFF
--- a/src/com/ashbysoft/wayland/Buffer.java
+++ b/src/com/ashbysoft/wayland/Buffer.java
@@ -30,7 +30,7 @@ public class Buffer extends WaylandObject<Buffer.Listener> {
     public boolean isBusy() { return _busy; }
 
     public boolean destroy() {
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         log(false, "destroy");
         return _display.write(b);
     }

--- a/src/com/ashbysoft/wayland/Compositor.java
+++ b/src/com/ashbysoft/wayland/Compositor.java
@@ -9,13 +9,13 @@ public class Compositor extends WaylandObject<Void> {
     public Compositor(Display d) { super(d); }
 
     public boolean createSurface(Surface s) {
-        ByteBuffer b = newBuffer(12, RQ_CREATE_SURFACE);
+        ByteBuffer b = newBuffer(4, RQ_CREATE_SURFACE);
         b.putInt(s.getID());
         log(false, "createSurface->"+s.getID());
         return _display.write(b);
     }
     public boolean createRegion(Region r) {
-        ByteBuffer b = newBuffer(12, RQ_CREATE_REGION);
+        ByteBuffer b = newBuffer(4, RQ_CREATE_REGION);
         b.putInt(r.getID());
         log(false, "createRegion->"+r.getID());
         return _display.write(b);

--- a/src/com/ashbysoft/wayland/Display.java
+++ b/src/com/ashbysoft/wayland/Display.java
@@ -129,14 +129,14 @@ public class Display extends WaylandObject<Display.Listener> {
 
     // requests
     private boolean sync(Callback cb) {
-        ByteBuffer m = newBuffer(12, RQ_SYNC);
+        ByteBuffer m = newBuffer(4, RQ_SYNC);
         m.putInt(cb.getID());
         log(false, "sync->"+cb.getID());
         return _conn.write(m);
     }
 
     public boolean getRegistry(Registry r) {
-        ByteBuffer m = newBuffer(12, RQ_GET_REGISTRY);
+        ByteBuffer m = newBuffer(4, RQ_GET_REGISTRY);
         m.putInt(r.getID());
         log(false, "getRegistry->"+r.getID());
         return write(m);

--- a/src/com/ashbysoft/wayland/Keyboard.java
+++ b/src/com/ashbysoft/wayland/Keyboard.java
@@ -96,7 +96,7 @@ public class Keyboard extends WaylandObject<Keyboard.Listener> {
     }
 
     public boolean release() {
-        ByteBuffer b = newBuffer(8, RQ_RELEASE);
+        ByteBuffer b = newBuffer(0, RQ_RELEASE);
         log(false, "release");
         return _display.write(b);
     }

--- a/src/com/ashbysoft/wayland/Pointer.java
+++ b/src/com/ashbysoft/wayland/Pointer.java
@@ -68,7 +68,7 @@ public class Pointer extends WaylandObject<Pointer.Listener> {
     }
 
     public boolean setCursor(int serial, Surface surface, int x, int y) {
-        ByteBuffer b = newBuffer(24, RQ_SET_CURSOR);
+        ByteBuffer b = newBuffer(16, RQ_SET_CURSOR);
         b.putInt(serial);
         b.putInt(surface.getID());
         b.putInt(x);
@@ -77,7 +77,7 @@ public class Pointer extends WaylandObject<Pointer.Listener> {
         return _display.write(b);
     }
     public boolean release() {
-        ByteBuffer b = newBuffer(8, RQ_RELEASE);
+        ByteBuffer b = newBuffer(0, RQ_RELEASE);
         log(false, "release");
         return _display.write(b);
     }

--- a/src/com/ashbysoft/wayland/Positioner.java
+++ b/src/com/ashbysoft/wayland/Positioner.java
@@ -43,19 +43,19 @@ public class Positioner extends WaylandObject<Void> {
     public Positioner(Display d) { super(d); }
     public boolean destroy() {
         log(false, "destroy");
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         return _display.write(b);
     }
     public boolean setSize(int w, int h) {
         log(false, "setSize:w="+w+",h="+h);
-        ByteBuffer b = newBuffer(16, RQ_SET_SIZE);
+        ByteBuffer b = newBuffer(8, RQ_SET_SIZE);
         b.putInt(w);
         b.putInt(h);
         return _display.write(b);
     }
     public boolean setAnchorRect(int x, int y, int w, int h) {
         log(false, "setAnchorRect:x="+x+",y="+y+",w="+w+",h="+h);
-        ByteBuffer b = newBuffer(24, RQ_SET_ANCHOR_RECT);
+        ByteBuffer b = newBuffer(16, RQ_SET_ANCHOR_RECT);
         b.putInt(x);
         b.putInt(y);
         b.putInt(w);
@@ -64,44 +64,44 @@ public class Positioner extends WaylandObject<Void> {
     }
     public boolean setAnchor(int a) {
         log(false, "setAnchor:a="+a);
-        ByteBuffer b = newBuffer(12, RQ_SET_ANCHOR);
+        ByteBuffer b = newBuffer(4, RQ_SET_ANCHOR);
         b.putInt(a);
         return _display.write(b);
     }
     public boolean setGravity(int g) {
         log(false, "setGravity:g="+g);
-        ByteBuffer b = newBuffer(12, RQ_SET_GRAVITY);
+        ByteBuffer b = newBuffer(4, RQ_SET_GRAVITY);
         b.putInt(g);
         return _display.write(b);
     }
     public boolean setConstraintAdjustment(int a) {
         log(false, "setConstraintAdjustment:a="+Integer.toHexString(a));
-        ByteBuffer b = newBuffer(12, RQ_SET_CONADJ);
+        ByteBuffer b = newBuffer(4, RQ_SET_CONADJ);
         b.putInt(a);
         return _display.write(b);
     }
     public boolean setOffset(int x, int y) {
         log(false, "setOffset:x="+x+",y="+y);
-        ByteBuffer b = newBuffer(16, RQ_SET_OFFSET);
+        ByteBuffer b = newBuffer(8, RQ_SET_OFFSET);
         b.putInt(x);
         b.putInt(y);
         return _display.write(b);
     }
     public boolean setReactive() {
         log(false, "setReactive");
-        ByteBuffer b = newBuffer(8, RQ_SET_REACTIVE);
+        ByteBuffer b = newBuffer(0, RQ_SET_REACTIVE);
         return _display.write(b);
     }
     public boolean setParentSize(int w, int h) {
         log(false, "setParentSize:w="+w+",h="+h);
-        ByteBuffer b = newBuffer(16, RQ_SET_PARENT_SIZE);
+        ByteBuffer b = newBuffer(8, RQ_SET_PARENT_SIZE);
         b.putInt(w);
         b.putInt(h);
         return _display.write(b);
     }
     public boolean setParentConfig(int serial) {
         log(false, "setParentConfig:serial="+serial);
-        ByteBuffer b = newBuffer(12, RQ_SET_PARENT_CONFIG);
+        ByteBuffer b = newBuffer(4, RQ_SET_PARENT_CONFIG);
         b.putInt(serial);
         return _display.write(b);
     }

--- a/src/com/ashbysoft/wayland/Region.java
+++ b/src/com/ashbysoft/wayland/Region.java
@@ -9,12 +9,12 @@ public class Region extends WaylandObject<Void> {
 
     public Region(Display d) { super(d); }
     public boolean destroy() {
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         log(false, "destroy");
         return _display.write(b);
     }
     public boolean add(int x, int y, int w, int h) {
-        ByteBuffer b = newBuffer(24, RQ_ADD);
+        ByteBuffer b = newBuffer(16, RQ_ADD);
         b.putInt(x);
         b.putInt(y);
         b.putInt(w);
@@ -23,7 +23,7 @@ public class Region extends WaylandObject<Void> {
         return _display.write(b);
     }
     public boolean subtract(int x, int y, int w, int h) {
-        ByteBuffer b = newBuffer(24, RQ_SUBTRACT);
+        ByteBuffer b = newBuffer(16, RQ_SUBTRACT);
         b.putInt(x);
         b.putInt(y);
         b.putInt(w);

--- a/src/com/ashbysoft/wayland/Registry.java
+++ b/src/com/ashbysoft/wayland/Registry.java
@@ -35,15 +35,12 @@ public class Registry extends WaylandObject<Registry.Listener> {
     }
 
     public boolean bind(int name, String iface, int version, WaylandBase obj) {
-        // [over]estimate buffer size from string length..
-        ByteBuffer b = newBuffer(24+iface.length()*2, RQ_BIND);
+        ByteBuffer b = newBuffer(12+strLen(iface), RQ_BIND);
         b.putInt(name);
         // https://www.mail-archive.com/wayland-devel@lists.freedesktop.org/msg40960.html
         putString(b, iface);
         b.putInt(version);
         b.putInt(obj.getID());
-        // adjust buffer limit now we have actual size
-        b.limit(b.position());
         log(false, "bind:name="+name+"->"+obj.getID());
         return _display.write(b);
     }

--- a/src/com/ashbysoft/wayland/Seat.java
+++ b/src/com/ashbysoft/wayland/Seat.java
@@ -39,25 +39,25 @@ public class Seat extends WaylandObject<Seat.Listener> {
     }
 
     public boolean getPointer(Pointer p) {
-        ByteBuffer b = newBuffer(12, RQ_GET_POINTER);
+        ByteBuffer b = newBuffer(4, RQ_GET_POINTER);
         b.putInt(p.getID());
         log(false, "getPointer:obj="+p.getID());
         return _display.write(b);
     }
     public boolean getKeyboard(Keyboard k) {
-        ByteBuffer b = newBuffer(12, RQ_GET_KEYBOARD);
+        ByteBuffer b = newBuffer(4, RQ_GET_KEYBOARD);
         b.putInt(k.getID());
         log(false, "getKeyboard:obj="+k.getID());
         return _display.write(b);
     }
     public boolean getTouch(Touch t) {
-        ByteBuffer b = newBuffer(12, RQ_GET_TOUCH);
+        ByteBuffer b = newBuffer(4, RQ_GET_TOUCH);
         b.putInt(t.getID());
         log(false, "getTouch:obj="+t.getID());
         return _display.write(b);
     }
     public boolean release() {
-        ByteBuffer b = newBuffer(8, RQ_RELEASE);
+        ByteBuffer b = newBuffer(0, RQ_RELEASE);
         log(false, "release");
         return _display.write(b);
     }

--- a/src/com/ashbysoft/wayland/Shm.java
+++ b/src/com/ashbysoft/wayland/Shm.java
@@ -26,7 +26,7 @@ public class Shm extends WaylandObject<Shm.Listener> {
 
     public ShmPool createPool(int sz) {
         ShmPool p = new ShmPool(_display, sz);
-        ByteBuffer b = newBuffer(16, RQ_CREATE_POOL);
+        ByteBuffer b = newBuffer(8, RQ_CREATE_POOL);
         b.putInt(p.getID());
         b.putInt(sz);
         log(false, "createPool->"+p.getID());

--- a/src/com/ashbysoft/wayland/ShmPool.java
+++ b/src/com/ashbysoft/wayland/ShmPool.java
@@ -35,7 +35,7 @@ public class ShmPool extends WaylandObject<Void> {
         v.order(ByteOrder.LITTLE_ENDIAN);
         // now associate that view with a buffer object
         Buffer buf = new Buffer(_display, v);
-        ByteBuffer b = newBuffer(32, RQ_CREATE_BUFFER);
+        ByteBuffer b = newBuffer(24, RQ_CREATE_BUFFER);
         b.putInt(buf.getID());
         b.putInt(off);
         b.putInt(w);
@@ -50,7 +50,7 @@ public class ShmPool extends WaylandObject<Void> {
         return buf;
     }
     public boolean destroy() {
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         log(false, "destroy");
         boolean rv = _display.write(b);
         // now destroy the local resources
@@ -58,7 +58,7 @@ public class ShmPool extends WaylandObject<Void> {
         return rv;
     }
     public boolean resize(int s) {
-        ByteBuffer b = newBuffer(12, RQ_RESIZE);
+        ByteBuffer b = newBuffer(4, RQ_RESIZE);
         b.putInt(s);
         log(false, "resize:size="+s);
         return _display.write(b);

--- a/src/com/ashbysoft/wayland/Surface.java
+++ b/src/com/ashbysoft/wayland/Surface.java
@@ -47,12 +47,12 @@ public class Surface extends WaylandObject<Surface.Listener> {
         return rv;
     }
     public boolean destroy() {
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         log(false, "destroy");
         return _display.write(b);
     }
     public boolean attach(Buffer buf, int x, int y) {
-        ByteBuffer b = newBuffer(20, RQ_ATTACH);
+        ByteBuffer b = newBuffer(12, RQ_ATTACH);
         b.putInt(buf!=null? buf.getID(): 0);
         b.putInt(x);
         b.putInt(y);
@@ -61,7 +61,7 @@ public class Surface extends WaylandObject<Surface.Listener> {
         return _display.write(b);
     }
     public boolean damage(int x, int y, int w, int h) {
-        ByteBuffer b = newBuffer(24, RQ_DAMAGE);
+        ByteBuffer b = newBuffer(16, RQ_DAMAGE);
         b.putInt(x);
         b.putInt(y);
         b.putInt(w);
@@ -70,42 +70,42 @@ public class Surface extends WaylandObject<Surface.Listener> {
         return _display.write(b);
     }
     public boolean frame(Callback cb) {
-        ByteBuffer b = newBuffer(12, RQ_FRAME);
+        ByteBuffer b = newBuffer(4, RQ_FRAME);
         b.putInt(cb.getID());
         log(false, "frame->"+cb.getID());
         return _display.write(b);
     }
     public boolean setOpaqueRegion(Region r) {
-        ByteBuffer b = newBuffer(12, RQ_SET_OPAQUE_REGION);
+        ByteBuffer b = newBuffer(4, RQ_SET_OPAQUE_REGION);
         b.putInt(r.getID());
         log(false, "setOpaqueRegion<-"+r.getID());
         return _display.write(b);
     }
     public boolean setInputRegion(Region r) {
-        ByteBuffer b = newBuffer(12, RQ_SET_INPUT_REGION);
+        ByteBuffer b = newBuffer(4, RQ_SET_INPUT_REGION);
         b.putInt(r.getID());
         log(false, "setInputRegion<-"+r.getID());
         return _display.write(b);
     }
     public boolean commit() {
-        ByteBuffer b = newBuffer(8, RQ_COMMIT);
+        ByteBuffer b = newBuffer(0, RQ_COMMIT);
         log(false, "commit");
         return _display.write(b);
     }
     public boolean setBufferTransform(int tr) {
-        ByteBuffer b = newBuffer(12, RQ_SET_BUFFER_TRANSFORM);
+        ByteBuffer b = newBuffer(4, RQ_SET_BUFFER_TRANSFORM);
         b.putInt(tr);
         log(false, "setBufferTransform:"+tr);
         return _display.write(b);
     }
     public boolean setBufferScale(int sc) {
-        ByteBuffer b = newBuffer(12, RQ_SET_BUFFER_SCALE);
+        ByteBuffer b = newBuffer(4, RQ_SET_BUFFER_SCALE);
         b.putInt(sc);
         log(false, "setBufferScale:"+sc);
         return _display.write(b);
     }
     public boolean damageBuffer(int x, int y, int w, int h) {
-        ByteBuffer b = newBuffer(24, RQ_DAMAGE_BUFFER);
+        ByteBuffer b = newBuffer(16, RQ_DAMAGE_BUFFER);
         b.putInt(x);
         b.putInt(y);
         b.putInt(w);

--- a/src/com/ashbysoft/wayland/WaylandObject.java
+++ b/src/com/ashbysoft/wayland/WaylandObject.java
@@ -3,6 +3,7 @@ package com.ashbysoft.wayland;
 import java.util.ArrayList;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 // base class for all protocol objects
 public abstract class WaylandObject<T> extends WaylandBase {
@@ -33,7 +34,9 @@ public abstract class WaylandObject<T> extends WaylandBase {
     }
     // parser/encoder helpers
     public ByteBuffer newBuffer(int size, int request) {
-        ByteBuffer r = ByteBuffer.allocate(size);
+        // https://wayland-book.com/protocol-design/wire-protocol.html#messages
+        // The message header is two words.
+        ByteBuffer r = ByteBuffer.allocate(8 + size);
         r.order(ByteOrder.nativeOrder());
         // always add our ID and the request
         r.putInt(getID());
@@ -58,6 +61,13 @@ public abstract class WaylandObject<T> extends WaylandBase {
             return new String(r, 0, r.length-1);
         return new String(r);
     }
+    // Pads to 32 bit boundary 
+    // https://wayland-book.com/protocol-design/wire-protocol.html
+    // array: A blob of arbitrary data, prefixed with a 32-bit integer specifying its length (in bytes), 
+    // then the verbatim contents of the array, padded to 32 bits with undefined data.
+    public int arrlen(int bytearraylen) {
+        return 4 + (bytearraylen+3)/4*4;
+    }
     public void putArray(ByteBuffer b, byte[] r) {
         int l = r.length;
         b.putInt(l);
@@ -68,9 +78,18 @@ public abstract class WaylandObject<T> extends WaylandBase {
             l += 1;
         }
     }
+    // Array capacity required to store string in UTF-8 + null terminator
+    // which is the format required by wayland
+    // https://wayland-book.com/protocol-design/wire-protocol.html
+    // https://github.com/phlash/swingland/issues/1
+    public int strLen(String s) {
+        return arrlen(s.getBytes(StandardCharsets.UTF_8).length + 1);
+    }
     public void putString(ByteBuffer b, String s) {
-        // we add a NUL terminator before encoding
-        s = s+"\0";
-        putArray(b, s.getBytes());
+        var strbytes = s.getBytes(StandardCharsets.UTF_8);
+        var foobytes = new byte[strbytes.length + 1];
+        System.arraycopy(strbytes, 0, foobytes, 0, strbytes.length);
+        foobytes[strbytes.length] = (byte)0;
+        putArray(b, foobytes);
     }
 }

--- a/src/com/ashbysoft/wayland/XdgPopup.java
+++ b/src/com/ashbysoft/wayland/XdgPopup.java
@@ -46,19 +46,19 @@ public class XdgPopup extends WaylandObject<XdgPopup.Listener> {
 
     public boolean destroy() {
         log(false, "destroy");
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         return _display.write(b);
     }
     public boolean grab(Seat seat, int serial) {
         log(false, "grab:seat="+seat.getID()+",serial="+serial);
-        ByteBuffer b = newBuffer(16, RQ_GRAB);
+        ByteBuffer b = newBuffer(8, RQ_GRAB);
         b.putInt(seat.getID());
         b.putInt(serial);
         return _display.write(b);
     }
     public boolean reposition(Positioner p, int token) {
         log(false, "reposition:pos="+p.getID()+",token="+token);
-        ByteBuffer b = newBuffer(16, RQ_REPOSITION);
+        ByteBuffer b = newBuffer(8, RQ_REPOSITION);
         b.putInt(p.getID());
         b.putInt(token);
         return _display.write(b);

--- a/src/com/ashbysoft/wayland/XdgSurface.java
+++ b/src/com/ashbysoft/wayland/XdgSurface.java
@@ -28,18 +28,18 @@ public class XdgSurface extends WaylandObject<XdgSurface.Listener> {
     }
 
     public boolean destroy() {
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         log(false, "destroy");
         return _display.write(b);
     }
     public boolean getTopLevel(XdgToplevel t) {
-        ByteBuffer b = newBuffer(12, RQ_GET_TOPLEVEL);
+        ByteBuffer b = newBuffer(4, RQ_GET_TOPLEVEL);
         b.putInt(t.getID());
         log(false, "getTopLevel->"+t.getID());
         return _display.write(b);
     }
     public boolean getPopup(XdgPopup u, XdgSurface x, Positioner p) {
-        ByteBuffer b = newBuffer(20, RQ_GET_POPUP);
+        ByteBuffer b = newBuffer(12, RQ_GET_POPUP);
         b.putInt(u.getID());
         b.putInt(x.getID());
         b.putInt(p.getID());
@@ -47,7 +47,7 @@ public class XdgSurface extends WaylandObject<XdgSurface.Listener> {
         return _display.write(b);
     }
     public boolean setWindowGeometry(int x, int y, int w, int h) {
-        ByteBuffer b = newBuffer(24, RQ_SET_WINDOW_GEOMETRY);
+        ByteBuffer b = newBuffer(16, RQ_SET_WINDOW_GEOMETRY);
         b.putInt(x);
         b.putInt(y);
         b.putInt(w);
@@ -56,7 +56,7 @@ public class XdgSurface extends WaylandObject<XdgSurface.Listener> {
          return _display.write(b);
     }
     public boolean ackConfigure(int serial) {
-        ByteBuffer b = newBuffer(12, RQ_ACK_CONFIGURE);
+        ByteBuffer b = newBuffer(4, RQ_ACK_CONFIGURE);
         b.putInt(serial);
         log(false, "ackConfigure:serial="+serial);
         return _display.write(b);

--- a/src/com/ashbysoft/wayland/XdgToplevel.java
+++ b/src/com/ashbysoft/wayland/XdgToplevel.java
@@ -52,34 +52,30 @@ public class XdgToplevel extends WaylandObject<XdgToplevel.Listener> {
         return rv;
     }
     public boolean destroy() {
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         log(false, "destroy");
         return _display.write(b);
     }
     public boolean setParent(XdgToplevel parent) {
-        ByteBuffer b = newBuffer(12, RQ_SET_PARENT);
+        ByteBuffer b = newBuffer(4, RQ_SET_PARENT);
         b.putInt(parent.getID());
         log(false, "setParent:"+parent.getID());
         return _display.write(b);
     }
     public boolean setTitle(String title) {
-        ByteBuffer b = newBuffer(8+title.length()*2, RQ_SET_TITLE);
+        ByteBuffer b = newBuffer(strLen(title), RQ_SET_TITLE);
         putString(b, title);
-        // adjust buffer limit now we know..
-        b.limit(b.position());
         log(false, "setTitle:"+title);
         return _display.write(b);
     }
     public boolean setAppID(String app) {
-        ByteBuffer b = newBuffer(8+app.length()*2, RQ_SET_APP_ID);
+        ByteBuffer b = newBuffer(strLen(app), RQ_SET_APP_ID);
         putString(b, app);
-        // adjust buffer limit now we know..
-        b.limit(b.position());
         log(false, "setAppID:"+app);
         return _display.write(b);
     }
     public boolean showWindowMenu(Seat seat, int serial, int x, int y) {
-        ByteBuffer b = newBuffer(24, RQ_SHOW_WINDOW_MENU);
+        ByteBuffer b = newBuffer(16, RQ_SHOW_WINDOW_MENU);
         b.putInt(seat.getID());
         b.putInt(serial);
         b.putInt(x);
@@ -88,14 +84,14 @@ public class XdgToplevel extends WaylandObject<XdgToplevel.Listener> {
         return _display.write(b);
     }
     public boolean move(Seat seat, int serial) {
-        ByteBuffer b = newBuffer(16, RQ_MOVE);
+        ByteBuffer b = newBuffer(8, RQ_MOVE);
         b.putInt(seat.getID());
         b.putInt(serial);
         log(false, "move:seat="+seat.getID()+" serial="+serial);
         return _display.write(b);
     }
     public boolean resize(Seat seat, int serial, int edges) {
-        ByteBuffer b = newBuffer(20, RQ_RESIZE);
+        ByteBuffer b = newBuffer(12, RQ_RESIZE);
         b.putInt(seat.getID());
         b.putInt(serial);
         b.putInt(edges);
@@ -103,42 +99,42 @@ public class XdgToplevel extends WaylandObject<XdgToplevel.Listener> {
         return _display.write(b);
     }
     public boolean setMaxSize(int w, int h) {
-        ByteBuffer b = newBuffer(16, RQ_SET_MAX_SIZE);
+        ByteBuffer b = newBuffer(8, RQ_SET_MAX_SIZE);
         b.putInt(w);
         b.putInt(h);
         log(false, "setMaxSize:w="+w+" h="+h);
         return _display.write(b);
     }
     public boolean setMinSize(int w, int h) {
-        ByteBuffer b = newBuffer(16, RQ_SET_MIN_SIZE);
+        ByteBuffer b = newBuffer(8, RQ_SET_MIN_SIZE);
         b.putInt(w);
         b.putInt(h);
         log(false, "setMinSize:w="+w+" h="+h);
         return _display.write(b);
     }
     public boolean setMaximized() {
-        ByteBuffer b = newBuffer(8, RQ_SET_MAXIMIZED);
+        ByteBuffer b = newBuffer(0, RQ_SET_MAXIMIZED);
         log(false, "setMaximized");
         return _display.write(b);
     }
     public boolean unsetMaximized() {
-        ByteBuffer b = newBuffer(8, RQ_UNSET_MAXIMIZED);
+        ByteBuffer b = newBuffer(0, RQ_UNSET_MAXIMIZED);
         log(false, "unsetMaximized");
         return _display.write(b);
     }
     public boolean setFullscreen(Output o) {
-        ByteBuffer b = newBuffer(12, RQ_SET_FULLSCREEN);
+        ByteBuffer b = newBuffer(4, RQ_SET_FULLSCREEN);
         b.putInt(o.getID());
         log(false, "setFullscreen:output="+o.getID());
         return _display.write(b);
     }
     public boolean unsetFullscreen() {
-        ByteBuffer b = newBuffer(8, RQ_UNSET_FULLSCREEN);
+        ByteBuffer b = newBuffer(0, RQ_UNSET_FULLSCREEN);
         log(false, "unsetFullscreen");
         return _display.write(b);
     }
     public boolean setMinimized() {
-        ByteBuffer b = newBuffer(8, RQ_SET_MINIMIZED);
+        ByteBuffer b = newBuffer(0, RQ_SET_MINIMIZED);
         log(false, "setMinimized");
         return _display.write(b);
     }

--- a/src/com/ashbysoft/wayland/XdgWmBase.java
+++ b/src/com/ashbysoft/wayland/XdgWmBase.java
@@ -28,25 +28,25 @@ public class XdgWmBase extends WaylandObject<XdgWmBase.Listener> {
     }
 
     public boolean destroy() {
-        ByteBuffer b = newBuffer(8, RQ_DESTROY);
+        ByteBuffer b = newBuffer(0, RQ_DESTROY);
         log(false, "destroy");
         return _display.write(b);
     }
     public boolean createPositioner(Positioner p) {
-        ByteBuffer b = newBuffer(12, RQ_CREATE_POSITIONER);
+        ByteBuffer b = newBuffer(4, RQ_CREATE_POSITIONER);
         b.putInt(p.getID());
         log(false, "createPositioner->"+p.getID());
         return _display.write(b);
     }
     public boolean getXdgSurface(XdgSurface x, Surface s) {
-        ByteBuffer b = newBuffer(16, RQ_GET_XDG_SURFACE);
+        ByteBuffer b = newBuffer(8, RQ_GET_XDG_SURFACE);
         b.putInt(x.getID());
         b.putInt(s.getID());
         log(false, "getXdgSurface->"+x.getID()+" s="+s.getID());
         return _display.write(b);
     }
     public boolean pong(int serial) {
-        ByteBuffer b = newBuffer(12, RQ_PONG);
+        ByteBuffer b = newBuffer(4, RQ_PONG);
         b.putInt(serial);
         log(false, "pong:serial="+serial);
         return _display.write(b);


### PR DESCRIPTION
There was a bug sending empty strings, caused by off-by-one. Also noticed that encoding was platform specific and not UTF-8 (as indicated by the wayland spec for most string methods)

Finally, buffer calculations can be exact, they don't need to overallocate.

Fixes https://github.com/phlash/swingland/issues/1